### PR TITLE
Fixed mislabeled method name in usage documentation page

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -134,7 +134,7 @@ A classifier can be trained on a set of predictions with::
 
 The classifier can the be used to generate predictions for a new dataset with::
 
-    >>> classifier.predict(new_predictions)
+    >>> classifier.classify(new_predictions)
     object_id SLSN  SNII  SNIIn SNIa  SNIbc
     --------- ----- ----- ----- ----- -----
     PS0909006 0.009 0.025 0.031 0.858 0.077


### PR DESCRIPTION
It said to use classifier.predict() to classify new predictions, but there is no predict() method on Classifier. It should be classifier.classify().