### PR TITLE
Make scipy output dim explicit as scipy default changed.

### DIFF
--- a/parsnip/light_curve.py
+++ b/parsnip/light_curve.py
@@ -28,7 +28,7 @@ def _determine_time_grid(light_curve):
 
     # Initial guess of the phase. Round everything to 0.1 days, and find the decimal
     # that has the largest count.
-    mode, count = scipy.stats.mode(np.round(sidereal_time % 1 + 0.05, 1))
+    mode, count = scipy.stats.mode(np.round(sidereal_time % 1 + 0.05, 1), keepdims=True)
     guess_offset = mode[0] - 0.05
 
     # Shift everything by the guessed offset


### PR DESCRIPTION
New scipy versions changed the default output dimension of e.g. mode. Change is to make it explicit to keep the dimensions such that it works with the mode[0] call. 